### PR TITLE
BBL-84 removing nightly trigger to validate makefile cmds work properly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,13 +102,13 @@ jobs:
 workflows:
   version: 2
   nightly_sync_and_release:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
+#    triggers:
+#      - schedule:
+#          cron: "0 0 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - master
     jobs:
       - git-sync-fork-upstream:
           context: binbashar-org-global-context


### PR DESCRIPTION
#### Commits on Jun 08, 2020
- @exequielrafaela - BBL-84 removing nightly trigger to validate makefile cmds work properly - 0667b9a