### PR TITLE
BBL-84 adding git clone makefile cmd + forcing upstream for release-m…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,21 +21,15 @@ jobs:
 
       - run:
           name: git-sync-fork-upstream-ansible
-          command: |
-          make git-clone-repo-ansible
-          make git-sync-fork-upstream-ansible
+          command: make git-clone-repo-ansible && make git-sync-fork-upstream-ansible
 
       - run:
           name: git-sync-fork-upstream-docker
-          command: |
-          make git-clone-repo-docker
-          make git-sync-fork-upstream-docker
+          command: make git-clone-repo-docker && make git-sync-fork-upstream-docker
 
       - run:
           name: git-sync-fork-upstream-terraform
-          command: |
-          make git-clone-repo-terraform
-          make git-sync-fork-upstream-terraform
+          command: make git-clone-repo-terraform && make git-sync-fork-upstream-terraform
 
   #
   # Grant all binbashar repo topics are setup


### PR DESCRIPTION
#### Commits on Jun 08, 2020
- @exequielrafaela - BBL-84 adding git clone makefile cmd + forcing upstream for release-mgmt circleci job step - 1a6b8b1
- @exequielrafaela - BBL-84 minor circleci/config.yaml sintaxt fix - cb46001