### PR TITLE
BBL-84 | forked repos -> upstream sync automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ workflows:
   nightly_sync_and_release:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 0 * * 0" # At 00:00 on Sunday
           filters:
             branches:
               only:


### PR DESCRIPTION
#### What?
- @exequielrafaela - BBL-84 CircileCI jobs tested -> scheduling sync pipeline to run nightly - 8dd97ba
- @exequielrafaela - BBL-84 update scheduling to a weekly frequency - 21b2107

#### Why?
Forked repos weekly automation for the below validated CircleCI jobs:
- :heavy_check_mark: :arrows_counterclockwise: **git-sync-fork-upstream:** https://circleci.com/gh/binbashar/le-dev-tools/46
- :heavy_check_mark: :arrows_counterclockwise: **github-repo-replace-all-topics:** https://circleci.com/gh/binbashar/le-dev-tools/47
- :heavy_check_mark: :arrows_counterclockwise: **release-version-with-changelog:**
https://circleci.com/gh/binbashar/le-dev-tools/48