### PR TITLE
BBL-192 | Updating repo list - terraform and ref-architecture

### DIFF
--- a/ref-architecture/Makefile
+++ b/ref-architecture/Makefile
@@ -17,6 +17,7 @@ define REPOS_LIST
 "le-helm-infra","" \
 "le-ref-architecture-doc","" \
 "le-tf-infra-aws","" \
+"le-tf-infra-aws-template","" \
 "le-tf-modules","" \
 "le-tf-vault",""
 endef

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -28,6 +28,7 @@ define REPOS_LIST
 "terraform-aws-ecr-cross-account","doingcloudright/terraform-aws-ecr-cross-account" \
 "terraform-aws-ecr-lifecycle-policy-rule","doingcloudright/terraform-aws-ecr-lifecycle-policy-rule" \
 "terraform-aws-eks","terraform-aws-modules/terraform-aws-eks" \
+"terraform-aws-elasticsearch","lgallard/terraform-aws-elasticsearch" \
 "terraform-aws-elasticache-redis","cloudposse/terraform-aws-elasticache-redis" \
 "terraform-aws-github-runner","philips-labs/terraform-aws-github-runner" \
 "terraform-aws-guardduty-monitor","opendevsecops/terraform-aws-guardduty-monitor" \


### PR DESCRIPTION
## What?
### Commits on Apr 30, 2021
- @exequielrafaela - BBL-192 | Updating repo list - terraform and ref-architecture - 6966a12

## Why? 
- Keeping Leverage DevOps Automation Code Library + Ref Architecture repos up to date.