### PR TITLE
BBL-192 | adding new ref-archietcture ghactions repos

### DIFF
--- a/ref-architecture/Makefile
+++ b/ref-architecture/Makefile
@@ -10,6 +10,7 @@ GIT_GITHUB_REPO_TOPICS := {"names": ["bb-le-refarch","binbash-refarch","binbash-
 define REPOS_LIST
 "ghaction-action-slack","8398a7/action-slack" \
 "ghaction-leverage-aws-credentials","" \
+"ghaction-leverage-configure-ref-arch","" \
 "ghaction-repository-dispatch","peter-evans/repository-dispatch" \
 "leverage","" \
 "le-ansible-infra","" \

--- a/ref-architecture/Makefile
+++ b/ref-architecture/Makefile
@@ -8,6 +8,9 @@ MAKEFILES_DIR := ../@bin/makefiles
 #
 GIT_GITHUB_REPO_TOPICS := {"names": ["bb-le-refarch","binbash-refarch","binbash-ref-architecture","ref-architecture"]}
 define REPOS_LIST
+"ghaction-action-slack","8398a7/action-slack" \
+"ghaction-leverage-aws-credentials","" \
+"ghaction-repository-dispatch","peter-evans/repository-dispatch" \
 "leverage","" \
 "le-ansible-infra","" \
 "le-architecture-diagrams","" \


### PR DESCRIPTION
## What?
### Commits on Jun 02, 2021
- @exequielrafaela - BBL-192 | adding new ref-archietcture ghactions repos - 0b8325b

## Why?
- Keep repo list in sync for tagging and automated upstream fork fetch and merge.