### PR TITLE
Add terraform-aws-apigateway-v2 module to the fork list

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -83,7 +83,8 @@ define REPOS_LIST
 "terraform-null-label","cloudposse/terraform-null-label","master" \
 "terraform-terraform-label","cloudposse/terraform-terraform-label","master" \
 "terraform-provider-postgresql","cyrilgdn/terraform-provider-postgresql","master" \
-"terraform-aws-ecr-public","cloudposse/terraform-aws-ecr-public","main"
+"terraform-aws-ecr-public","cloudposse/terraform-aws-ecr-public","main" \
+"terraform-aws-apigateway-v2","terraform-aws-modules/terraform-aws-apigateway-v2","master"
 endef
 
 help:


### PR DESCRIPTION
## what
* Add terraform-aws-modules/terraform-aws-apigateway-v2 module to the fork list

## why
* Should be self-explanatory

## references
N/A

