### PR TITLE
fix | fixing terraform repo list missing slash

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -83,7 +83,7 @@ define REPOS_LIST
 "terraform-aws-wafv2","trussworks/terraform-aws-wafv2","main" \
 "terraform-aws-waf-webaclv2","umotif-public/terraform-aws-waf-webaclv2","main" \
 "terraform-null-label","cloudposse/terraform-null-label","main" \
-"terraform-playground","","master"
+"terraform-playground","","master" \
 "terraform-provider-postgresql","cyrilgdn/terraform-provider-postgresql","master" \
 "terraform-provider-sops","carlpett/terraform-provider-sops","master" \
 "terraform-terraform-label","cloudposse/terraform-terraform-label","main"


### PR DESCRIPTION
## What? 

### Commits on Jun 23, 2023
- [fixing terraform repo list missing slash](https://github.com/binbashar/le-dev-tools/commit/890c0154b05ff0bba92885415868137314fd7dbf) - @[exequielrafaela](https://github.com/binbashar/le-dev-tools/commits?author=exequielrafaela)

## Why?
- Failing CI pipeline https://app.circleci.com/pipelines/github/binbashar/le-dev-tools/834/workflows/e360a528-55a3-4c71-b582-d3676e933af2/jobs/1302