### PR TITLE
Fix | remove nginx role entries from Makefile

### DIFF
--- a/ansible/roles/Makefile
+++ b/ansible/roles/Makefile
@@ -37,8 +37,8 @@ define REPOS_LIST
 "ansible-role-logrotate","nickhammond/ansible-logrotate","master" \
 "ansible-role-mongodb","UnderGreen/ansible-role-mongodb","master" \
 "ansible-role-nginx","jdauphant/ansible-role-nginx","master" \
-"ansible-role-nginxinc-nginx","nginxinc/ansible-role-nginx","main" \
-"ansible-role-nginx-config","nginxinc/ansible-role-nginx-config","main" \
+# "ansible-role-nginxinc-nginx","nginxinc/ansible-role-nginx","main" \
+# "ansible-role-nginx-config","nginxinc/ansible-role-nginx-config","main" \
 "ansible-role-security","geerlingguy/ansible-role-security","master" \
 "ansible-role-users","","" \
 "ansible-role-vault","ansible-community/ansible-vault","master" \


### PR DESCRIPTION
## what
* remove nginx role entries from Makefile

## why
* Fix ansible sync fork errors
<img width="556" alt="image" src="https://github.com/user-attachments/assets/f676501f-b0f0-476f-afc2-e26a3b430da4" />


## references
* [https://binbashar.slack.com/archives/G5MVCJ48K/p1738454739422589

